### PR TITLE
ezmomi status' can show more VM info & new way to print the output (a 'grep' firendly one)

### DIFF
--- a/ezmomi/ezmomi.py
+++ b/ezmomi/ezmomi.py
@@ -412,11 +412,16 @@ class EZMomi(object):
 
         status_to_print = []
         if extra:
-            status_to_print = [["vmname", "powerstate", "ipaddress", "hostname", "memory", "cpunum", "uuid", "guestid", "uptime"]] + \
-                              [[vm.name, vm.runtime.powerState, vm.summary.guest.ipAddress or '',
-                                vm.summary.guest.hostName or '', str(vm.summary.config.memorySizeMB),
-                                str(vm.summary.config.numCpu), vm.summary.config.uuid, vm.summary.guest.guestId,
-                                str(vm.summary.quickStats.uptimeSeconds) or '0']]
+            status_to_print = \
+                [["vmname", "powerstate", "ipaddress", "hostname", "memory",
+                  "cpunum", "uuid", "guestid", "uptime"]] + \
+                [[vm.name, vm.runtime.powerState,
+                  vm.summary.guest.ipAddress or '',
+                  vm.summary.guest.hostName or '',
+                  str(vm.summary.config.memorySizeMB),
+                  str(vm.summary.config.numCpu),
+                  vm.summary.config.uuid, vm.summary.guest.guestId,
+                  str(vm.summary.quickStats.uptimeSeconds) or '0']]
         else:
             status_to_print = [[vm.name, vm.runtime.powerState]]
 
@@ -505,7 +510,7 @@ class EZMomi(object):
     def print_as_lines(self, data):
         maxLen = 0
         for row in data:
-            maxLen=len(row) if len(row) > maxLen else maxLen
+            maxLen = len(row) if len(row)>maxLen else maxLen
 
         # all rows will have same size
         for row in data:
@@ -518,7 +523,6 @@ class EZMomi(object):
                 sys.stdout.write("=")
             sys.stdout.write (str(data[rowNr-1][index]))
             print
-
 
     def listSnapshots(self):
         root_snapshot_list = self.get_all_snapshots(self.config['vm'])

--- a/ezmomi/ezmomi.py
+++ b/ezmomi/ezmomi.py
@@ -510,7 +510,7 @@ class EZMomi(object):
     def print_as_lines(self, data):
         maxlen = 0
         for row in data:
-            maxlen = len(row) if len(row)>maxlen else maxlen
+            maxlen = len(row) if len(row) > maxlen else maxlen
 
         # all rows will have same size
         for row in data:

--- a/ezmomi/ezmomi.py
+++ b/ezmomi/ezmomi.py
@@ -148,7 +148,7 @@ class EZMomi(object):
             else:
                 rows.append([c._moId, c.name])
 
-        self.tabulate(rows)
+        self.print_as_table(rows)
 
     def clone(self):
         """
@@ -407,7 +407,23 @@ class EZMomi(object):
     def status(self):
         """Check power status"""
         vm = self.get_vm_failfast(self.config['name'])
-        self.tabulate([[vm.name, vm.runtime.powerState]])
+        extra = self.config['extra']
+        parserFriendly = self.config['parserFriendly']
+
+        status_to_print = []
+        if extra:
+            status_to_print = [["vmname", "powerstate", "ipaddress", "hostname", "memory", "cpunum", "uuid", "guestid", "uptime"]] + \
+                              [[vm.name, vm.runtime.powerState, vm.summary.guest.ipAddress or '',
+                                vm.summary.guest.hostName or '', str(vm.summary.config.memorySizeMB),
+                                str(vm.summary.config.numCpu), vm.summary.config.uuid, vm.summary.guest.guestId,
+                                str(vm.summary.quickStats.uptimeSeconds) or '0']]
+        else:
+            status_to_print = [[vm.name, vm.runtime.powerState]]
+
+        if parserFriendly:
+            self.print_as_lines(status_to_print)
+        else:
+            self.print_as_table(status_to_print)
 
     def shutdown(self):
         """
@@ -464,7 +480,7 @@ class EZMomi(object):
                     self.get_all_snapshots(vm) if
                     snapshot.name == name)
 
-    def tabulate(self, data):
+    def print_as_table(self, data):
         column_widths = []
 
         for row in data:
@@ -486,6 +502,24 @@ class EZMomi(object):
         for row in data:
             print format.format(*row)
 
+    def print_as_lines(self, data):
+        maxLen = 0
+        for row in data:
+            maxLen=len(row) if len(row) > maxLen else maxLen
+
+        # all rows will have same size
+        for row in data:
+            row.extend((maxLen-len(row)) * [''])
+
+        rowNr = len(data)
+        for index in range(0, maxLen):
+            for row in range(0, rowNr-1):
+                sys.stdout.write(str(data[row][index]))
+                sys.stdout.write("=")
+            sys.stdout.write (str(data[rowNr-1][index]))
+            print
+
+
     def listSnapshots(self):
         root_snapshot_list = self.get_all_snapshots(self.config['vm'])
 
@@ -496,7 +530,7 @@ class EZMomi(object):
                                   str(snapshot.createTime)])
 
             data = [['VM', 'Snapshot', 'Create Time']] + snapshots
-            self.tabulate(data)
+            self.print_as_table(data)
         else:
             print "No snapshots for %s" % self.config['vm']
 

--- a/ezmomi/ezmomi.py
+++ b/ezmomi/ezmomi.py
@@ -508,20 +508,20 @@ class EZMomi(object):
             print format.format(*row)
 
     def print_as_lines(self, data):
-        maxLen = 0
+        maxlen = 0
         for row in data:
-            maxLen = len(row) if len(row)>maxLen else maxLen
+            maxlen = len(row) if len(row)>maxlen else maxlen
 
         # all rows will have same size
         for row in data:
-            row.extend((maxLen-len(row)) * [''])
+            row.extend((maxlen-len(row)) * [''])
 
         rowNr = len(data)
-        for index in range(0, maxLen):
+        for index in range(0, maxlen):
             for row in range(0, rowNr-1):
                 sys.stdout.write(str(data[row][index]))
                 sys.stdout.write("=")
-            sys.stdout.write (str(data[rowNr-1][index]))
+            sys.stdout.write(str(data[rowNr-1][index]))
             print
 
     def listSnapshots(self):

--- a/ezmomi/ezmomi.py
+++ b/ezmomi/ezmomi.py
@@ -470,6 +470,19 @@ class EZMomi(object):
         result = self.WaitForTasks(tasks)
         print "Created snapshot for %s" % vm.name
 
+    def get_snapshots_recursive(self, snap_tree):
+        local_snap = []
+        for snap in snap_tree:
+            local_snap.append(snap)
+            # print "local_snap1=", local_snap
+        for snap in snap_tree:
+            recurse_snap = self.get_snapshots_recursive(snap.childSnapshotList)
+            if recurse_snap:
+                local_snap.extend(recurse_snap)
+            # print "local_snap2=", local_snap
+        # print "local_snap3=", local_snap
+        return local_snap
+
     def get_all_snapshots(self, vm_name):
         vm = self.get_vm_failfast(vm_name)
 
@@ -478,7 +491,7 @@ class EZMomi(object):
         except IndexError:
             return
 
-        return vm_snapshot_info.rootSnapshotList
+        return self.get_snapshots_recursive(vm_snapshot_info.rootSnapshotList)
 
     def get_snapshot_by_name(self, vm, name):
         return next(snapshot.snapshot for snapshot in

--- a/ezmomi/ezmomi.py
+++ b/ezmomi/ezmomi.py
@@ -474,13 +474,10 @@ class EZMomi(object):
         local_snap = []
         for snap in snap_tree:
             local_snap.append(snap)
-            # print "local_snap1=", local_snap
         for snap in snap_tree:
             recurse_snap = self.get_snapshots_recursive(snap.childSnapshotList)
             if recurse_snap:
                 local_snap.extend(recurse_snap)
-            # print "local_snap2=", local_snap
-        # print "local_snap3=", local_snap
         return local_snap
 
     def get_all_snapshots(self, vm_name):

--- a/ezmomi/params.py
+++ b/ezmomi/params.py
@@ -244,7 +244,8 @@ def arg_setup():
         required=False,
         action='store_true',
         default=False,
-        help="Extra VM status (vm name, power status, ip address, hostname, memory, cpu num, uuid, guest id, uptime)"
+        help="Extra VM status (vm name, power status, ip address, hostname, "
+             "memory, cpu num, uuid, guest id, uptime)"
     )
     status_parser.add_argument(
         "--parserFriendly",

--- a/ezmomi/params.py
+++ b/ezmomi/params.py
@@ -239,6 +239,20 @@ def arg_setup():
         required=True,
         help="VM name (case-sensitive)"
     )
+    status_parser.add_argument(
+        "--extra",
+        required=False,
+        action='store_true',
+        default=False,
+        help="Extra VM status (vm name, power status, ip address, hostname, memory, cpu num, uuid, guest id, uptime)"
+    )
+    status_parser.add_argument(
+        "--parserFriendly",
+        required=False,
+        action='store_true',
+        default=False,
+        help="Friendly output for easy parsing"
+    )
 
     # shutdown
     shutdown_parser = subparsers.add_parser(


### PR DESCRIPTION
In this pull request contains 2 changes
1. 'ezmoni status' has one extra parameter named '--extra' which will print multiple VM details.
2 added a new '--parserFriendly' parameter for 'ezmomi status'.

Some comments related with those changes:

- I've tried to use the same code style in my changes, if I've failed to do that, please give me some feedback and I will try to fix that. you will see that I've used 'sys.stdout.write' instead of 'print'. The reason is this: http://stackoverflow.com/questions/255147/how-do-i-keep-python-print-from-adding-newlines-or-spaces . For python2 I don't see a simpler way to do that without to confuse others.
- I've changed the 'tabulate' name to 'print_as_table' since I've added another way to deliver the output 'print_as_lines'.

All those changes were done based on my actual needs. I hope that they help the community.

I hope this one will pass PEP8 checks.